### PR TITLE
chore(web): add Bun-friendly build scripts and fix SSR build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,9 @@
 	"type": "module",
 	"scripts": {
 		"dev": "react-router dev",
+		"build": "react-router build",
+		"start": "react-router-serve ./build/server/index.js",
+		"preview": "react-router build && react-router-serve ./build/server/index.js",
 		"typecheck": "react-router typegen && tsc --noEmit"
 	},
 	"dependencies": {

--- a/apps/web/react-router.config.ts
+++ b/apps/web/react-router.config.ts
@@ -3,5 +3,7 @@ import type { Config } from '@react-router/dev/config';
 export default {
 	appDirectory: './src/app',
 	ssr: true,
-	prerender: ['/*?'],
+	// Temporarily disable prerendering during the build process.
+	// Re-enable once the underlying SSR issues are resolved.
+	prerender: [],
 } satisfies Config;

--- a/apps/web/src/__create/fetch.ts
+++ b/apps/web/src/__create/fetch.ts
@@ -9,10 +9,13 @@ const safeStringify = (value: unknown) =>
     return v;
   });
 
-const postToParent = (level: string, text: string, extra: unknown) => {
+const postToParent = (level: 'log' | 'warn' | 'error', text: string, extra: unknown) => {
   try {
     if (isBackend() || !window.parent || window.parent === window) {
-      ('level' in console ? console[level] : console.log)(text, extra);
+      const fn = (
+        level in console ? (console as any)[level] : console.log
+      ) as (...args: any[]) => void;
+      fn(text, extra);
       return;
     }
     window.parent.postMessage(

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -13,6 +13,7 @@
 		"module": "ES2022",
 		"moduleResolution": "bundler",
 		"jsx": "react-jsx",
+		"allowJs": true,
 		"rootDirs": [".", "./.react-router/types"],
 		"baseUrl": ".",
 		"esModuleInterop": true,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -77,6 +77,10 @@ export default defineConfig({
     },
     dedupe: ['react', 'react-dom'],
   },
+  // Prevent react-idle-timer (CJS) from being externalized during SSR build
+  ssr: {
+    noExternal: ['react-idle-timer'],
+  },
   clearScreen: false,
   server: {
     allowedHosts: true,


### PR DESCRIPTION
- Add build/start/preview scripts using react-router CLI

- Enable allowJs to satisfy typegen imports from .jsx files

- Fix console level access in fetch helper (ts error)

- Bundle CJS react-idle-timer in SSR (noExternal)

- Refactor API route registration to import.meta.glob (no fs at runtime)

- Disable prerender for now to ensure successful builds

Droid-assisted